### PR TITLE
feat: show only statistics

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -12,7 +12,7 @@ var log = New(Level).Sugar()
 // Execute main function
 func Execute() {
 
-	var interactive, quiet, debug bool
+	var interactive, stats, quiet, debug bool
 	var username, filename, customDict string
 
 	app := &cli.App{
@@ -38,6 +38,11 @@ func Execute() {
 				Destination: &interactive,
 				Value:       false,
 				Usage:       "enable interactive mode asking data from console"},
+			&cli.BoolFlag{Name: "stats",
+				Aliases:     []string{"s"},
+				Destination: &stats,
+				Value:       false,
+				Usage:       "display only statistics"},
 			&cli.BoolFlag{Name: "quiet",
 				Aliases:     []string{"q"},
 				Destination: &quiet,
@@ -83,9 +88,9 @@ func Execute() {
 			}
 
 			if filename != "" {
-				return checkMultiplePassword(filename, customDict, interactive)
+				return checkMultiplePassword(filename, customDict, interactive, stats)
 			}
-			return checkSinglePassword(username, password, customDict, quiet)
+			return checkSinglePassword(username, password, customDict, quiet, stats)
 
 		},
 	}

--- a/cmd/core_test.go
+++ b/cmd/core_test.go
@@ -190,6 +190,67 @@ func TestShowTable(t *testing.T) {
 	}
 }
 
+func TestShowStats(t *testing.T) {
+
+	tests := []struct {
+		name string
+		in   statistics
+		out  string
+	}{
+		{
+			name: "Single row",
+			in: statistics{
+				TotCount:       1,
+				WordsCount:     59824,
+				ScoreCount:     []int{0, 0, 0, 0, 1},
+				DuplicateCount: 0,
+			},
+			out: `       DESCRIPTION      | COUNT  
+------------------------+--------
+  Password checked      |     1  
+  Words in dictionaries | 59824  
+  Really bad passwords  |     0  
+  Bad passwords         |     0  
+  Weak passwords        |     0  
+  Good passwords        |     0  
+  Strong passwords      |     1  
+`,
+		},
+		{
+			name: "Multiple row",
+			in: statistics{
+				TotCount:       9,
+				WordsCount:     59824,
+				ScoreCount:     []int{3, 1, 2, 1, 2},
+				DuplicateCount: 0,
+			},
+			out: `       DESCRIPTION      | COUNT  
+------------------------+--------
+  Password checked      |     9  
+  Words in dictionaries | 59824  
+  Really bad passwords  |     3  
+  Bad passwords         |     1  
+  Weak passwords        |     2  
+  Good passwords        |     1  
+  Strong passwords      |     2  
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			buf := &bytes.Buffer{}
+			showStats(tt.in, buf)
+
+			if !reflect.DeepEqual(tt.out, buf.String()) {
+				t.Fatalf("got %s, expected %s", buf.String(), tt.out)
+			}
+
+		})
+	}
+}
+
 func TestReadCSV(t *testing.T) {
 
 	type CSVData struct {


### PR DESCRIPTION
Add `-s` or `--stats` parameter to show only statistics:
```
./check-password-strength -s -f test/example.csv 
       DESCRIPTION      | COUNT  
------------------------+--------
  Password checked      |     9  
  Words in dictionaries | 59824  
  Really bad passwords  |     3  
  Duplicated passwords  |     0  
  Bad passwords         |     1  
  Weak passwords        |     2  
  Good passwords        |     1  
  Strong passwords      |     2
```
Closes #8